### PR TITLE
Remove duplicate home delete from remove script

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ If you don't have YunoHost, please consult [the guide](https://yunohost.org/#/in
 
 TV streaming server and recorder
 
-**Shipped version:** 4.3.2009~ynh9
+**Shipped version:** 4.3.2009~ynh10
 
 
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -13,7 +13,7 @@ Si vous n'avez pas YunoHost, regardez [ici](https://yunohost.org/#/install) pour
 
 Serveur de streaming et d'enregistrement TV
 
-**Version incluse :** 4.3.2009~ynh9
+**Version incluse :** 4.3.2009~ynh10
 
 
 

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
         "en": "TV streaming server and recorder",
         "fr": "Serveur de streaming et d'enregistrement TV"
     },
-    "version": "4.3.2009~ynh9",
+    "version": "4.3.2009~ynh10",
     "url": "https://tvheadend.org",
     "upstream": {
         "license": "GPL-3.0",

--- a/scripts/remove
+++ b/scripts/remove
@@ -60,14 +60,6 @@ ynh_script_progression --message="Removing Tvheadend..." --weight=6
 ynh_package_autopurge $app
 
 #=================================================
-# REMOVE APP MAIN DIR AND CONFIG FILES
-#=================================================
-ynh_script_progression --message="Removing app main directory..." --weight=2
-
-# Remove the app directory securely
-ynh_secure_remove --file="$final_path"
-
-#=================================================
 # REMOVE NGINX CONFIGURATION
 #=================================================
 ynh_script_progression --message="Removing NGINX web server configuration..." --weight=1


### PR DESCRIPTION
`/home/hts` is already removed by `deluser  hts --remove-home` line so this step is not necessary